### PR TITLE
chore: Fix code scanning alert "Workflow does not contain permissions"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/devadathanmb/ktu-bot/security/code-scanning/1](https://github.com/devadathanmb/ktu-bot/security/code-scanning/1)

To address the issue, add a `permissions` block that restricts the GitHub token to the absolute minimum for this job. Standard CI build processes like installing dependencies, linting, and building code generally require only `contents: read`, to fetch code and check out the repo. You should add a `permissions` block with `contents: read` at either the job (`build`) or the workflow (top-level, after `name:` and `on:`) level. The most future-proof way is to specify it at the root of the workflow file, ensuring all jobs inherit this minimal permission unless explicitly overridden. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
